### PR TITLE
Adding public/private path indicator to dashboard single path view

### DIFF
--- a/client/components/paths/path-single.js
+++ b/client/components/paths/path-single.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PathProgress from './path-progress'
 import AddResource from './add-resource'
+import PathToggleStatus from './path-toggle-status'
 
 import { deleteSinglePathThunk, getStepCompletionSingleUserThunk, toggleStepCompletionThunk } from '../../store'
 
@@ -13,6 +14,7 @@ import Collapse from '@material-ui/core/Collapse'
 import ExpandLess from '@material-ui/icons/ExpandLess'
 import ExpandMore from '@material-ui/icons/ExpandMore'
 import Button from '@material-ui/core/Button'
+import Chip from '@material-ui/core/Chip'
 
 const styles = {
   container: {
@@ -24,6 +26,10 @@ const styles = {
   deleteButton: {
     marginTop: 20,
     float: 'right'
+  },
+  chip: {
+    fontWeight: 100,
+    marginRight: 20
   }
 }
 
@@ -108,11 +114,18 @@ class SinglePath extends Component {
     return Math.round( (completed / total) * 100 )
   }
 
+  toggleStatus = () => {
+
+  }
+
   render(){
     const { path, user } = this.props
     return (
       <div>
-        <h3>{path.details.properties.name}</h3>
+        <h3>
+          <Chip label={path.details.properties.status} style={styles.chip}/>
+          {path.details.properties.name}
+        </h3>
         <p>{path.details.properties.description}</p>
 
         { this.props.path.steps[0].step !== null &&
@@ -183,14 +196,21 @@ class SinglePath extends Component {
         </div>
 
         { path.details.properties.owner === user &&
-          <Button
-            style={styles.deleteButton}
-            onClick={this.handleDeletePath}
-            variant="outlined"
-            color="secondary"
-          >
-          Delete Path
-          </Button>
+          <div>
+            <Button
+              style={styles.deleteButton}
+              onClick={this.handleDeletePath}
+              variant="outlined"
+              color="secondary"
+            >
+            Delete Path
+            </Button>
+
+            <PathToggleStatus
+              toggleStatus={this.state.toggleStatus}
+              style={styles.status} />
+
+          </div>
         }
 
       </div>

--- a/client/components/paths/path-toggle-status.js
+++ b/client/components/paths/path-toggle-status.js
@@ -1,0 +1,29 @@
+import React, {Component} from 'react'
+import Switch from '@material-ui/core/Switch'
+
+class PathToggleStatus extends Component {
+
+  state = {
+    status: true
+  }
+
+  handleChange = name => event => {
+    this.setState({ [name]: event.target.checked });
+  }
+
+  render() {
+    return (
+      <div>
+        <p>Toggle Path Public or Private</p>
+        <Switch
+          checked={this.state.status}
+          onChange={this.handleChange('status')}
+          value="status"
+          color="primary"
+        />
+      </div>
+    );
+  }
+}
+
+export default PathToggleStatus

--- a/client/components/paths/public-single-path.js
+++ b/client/components/paths/public-single-path.js
@@ -118,7 +118,6 @@ class PublicSinglePath extends Component {
 }
 
 const mapStateToProps = (state) => {
-  console.log('path state', state)
   return {
     completedSteps: state.pathReducer.singlePath
   }


### PR DESCRIPTION
This will add a chip to the title of single path view in the user dashboard that indicates if the path is public or private.

<img width="597" alt="screen shot 2018-06-28 at 6 08 17 am" src="https://user-images.githubusercontent.com/872479/42030832-b5f32632-7a99-11e8-9e28-ce31f02cf802.png">

There is also a toggle available to owners of a path to make it public or private which will toggle but it doesn't update the path status yet:

<img width="898" alt="screen shot 2018-06-28 at 6 09 57 am" src="https://user-images.githubusercontent.com/872479/42030934-03336d58-7a9a-11e8-82f0-f6466d0721f4.png">


